### PR TITLE
Added index.html to Info.plist

### DIFF
--- a/lib/doc_to_dash.rb
+++ b/lib/doc_to_dash.rb
@@ -151,6 +151,8 @@ module DocToDash
           <string>{DOCSET_NAME}</string>
           <key>isDashDocset</key>
           <true/>
+          <key>dashIndexFilePath</key>
+          <string>#{@options[:doc_save_folder]}/index.html</string>
         </dict>
         </plist>
 XML


### PR DESCRIPTION
By adding docs/index.html to the Info.plist the index.html will be the default page viewed in Dash when the docset is selected (instead of a blank page).  Since both rdoc and yard generate an index.html, this should be safe.
