### PR TITLE
Fix it cannot use RdocDarkfishParser on CLI

### DIFF
--- a/lib/doc_to_dash.rb
+++ b/lib/doc_to_dash.rb
@@ -1,6 +1,7 @@
 require "doc_to_dash/version"
 require "doc_to_dash/cli"
 require "doc_to_dash/parsers/yard_parser" # Required because it defaults to this.
+require "doc_to_dash/parsers/rdoc_darkfish_parser"
 require 'sqlite3'
 require 'fileutils'
 require 'nokogiri'


### PR DESCRIPTION
I tried to use `RdocDarkfishParser` from CLI. 
However, the parser seems not to be loaded.

```
$ doc_to_dash doc -o docset -p RdocDarkfishParser
```

```
/Users/giginet/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/doc_to_dash-0.0.9/lib/doc_to_dash/cli.rb:30:in `const_get': uninitialized constant RdocDarkfishParser (NameError)
        from /Users/giginet/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/doc_to_dash-0.0.9/lib/doc_to_dash/cli.rb:30:in `run'
        from /Users/giginet/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/doc_to_dash-0.0.9/lib/doc_to_dash/cli.rb:6:in `run'
        from /Users/giginet/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/doc_to_dash-0.0.9/bin/doc_to_dash:4:in `<top (required)>'
        from /Users/giginet/.rbenv/versions/2.2.3/bin/doc_to_dash:23:in `load'
        from /Users/giginet/.rbenv/versions/2.2.3/bin/doc_to_dash:23:in `<main>'
```

So I fixed it. Please check it out.