### PR TITLE
Adding additional files in YARD docs to docset as Guides

### DIFF
--- a/lib/doc_to_dash.rb
+++ b/lib/doc_to_dash.rb
@@ -11,6 +11,7 @@ module DocToDash
     def initialize(options = {})
       @classes      = []
       @methods      = []
+      @files        = []
 
       @options = {
           :docset_name            => 'DefaultDocset',
@@ -48,10 +49,12 @@ module DocToDash
 
       @classes = parser.parse_classes
       @methods = parser.parse_methods
+      @files = parser.parse_files rescue []
 
       if @methods && @classes
         load_methods_into_database
         load_classes_into_database
+        load_files_into_database
 
         log "Docset created."
         @docset_path
@@ -133,6 +136,11 @@ module DocToDash
     def load_classes_into_database
       log "Loading classes into database."
       insert_into_database @classes, 'cl'
+    end
+
+    def load_files_into_database
+      log "Loading files into database."
+      insert_into_database @files, 'Guide'
     end
 
     def insert_into_database(array, type)

--- a/lib/doc_to_dash/parsers/rdoc_darkfish_parser.rb
+++ b/lib/doc_to_dash/parsers/rdoc_darkfish_parser.rb
@@ -53,5 +53,10 @@ module DocToDash
       @methods
     end
     alias :parse_methods :methods
+
+    def files
+      raise 'Not implemented!'
+    end
+    alias :parse_files :files
   end
 end

--- a/lib/doc_to_dash/parsers/yard_parser.rb
+++ b/lib/doc_to_dash/parsers/yard_parser.rb
@@ -41,5 +41,14 @@ module DocToDash
 
       methods
     end
+
+    def parse_files
+      file_list = Dir.glob File.join(@doc_directory, 'file.*.html')
+      file_list.inject [] do |files, filename|
+        base_name = File.basename(filename)
+        section_name = base_name.gsub(/file.|.html/, '')
+        files << [ base_name, section_name ]
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi Caleb!

First of all, thank you for this tool - it's awesome! We're using it at my organization to place our internal yard-based docs into Dash and Zeal. Unfortunately, some of the docs we have don't really fit in with the "docs-in-code" format of yardoc - e.g. the usage, care and feeding of a particularly complicated concern. These docs are currently kept outside yard.

I've proposed that we move them into .md or .rdoc files and have yard include those in the generated docs. This idea got some strong support - provided I can get this kind of docs into Dash/Zeal as well.

Yard always places additional files in file.originalfilename.html, so their detection and addition to the docset turned out to be trivial :) The only problem with this is - it only works for Yard docs right now; I simply don't have any Rdoc-style docs which would include external files in this manner handy..

I'm opening this pull request nonetheless - it won't crash on Rdoc, it just won't generate the Guides part. Maybe someone will find the yard half useful ;)
