### PR TITLE
Fix 0.9.0 breaking YARD change

### DIFF
--- a/lib/doc_to_dash/parsers/yard_parser.rb
+++ b/lib/doc_to_dash/parsers/yard_parser.rb
@@ -15,7 +15,7 @@ module DocToDash
       classes_html = Nokogiri::HTML(classes_file)
       classes      = []
 
-      classes_html.xpath('//li').children.select{|c| c.name == "span"}.each do |method|
+      classes_html.css('span.object_link').each do |method|
         a     = method.children.first
         title = a.children.first.to_s.gsub('#', '')
         href  = a["href"].to_s
@@ -31,7 +31,7 @@ module DocToDash
       methods_html = Nokogiri::HTML(methods_file)
       methods      = []
 
-      methods_html.xpath('//li').children.select{|c| c.name == "span"}.each do |method|
+      methods_html.css('span.object_link').each do |method|
         a     = method.children.first
         href  = a["href"].to_s
         name  = a["title"].to_s.gsub(/\((.+)\)/, '').strip! # Strip the (ClassName) and whitespace.


### PR DESCRIPTION
 >= 0.9.0 in YARD version changes the DOM structure of the templates
 which broke the nokogiri finder. This results in the docset being
 empty, changing the nokogiri the finder fixes the problem. This change
 also should be backwards compatible because the tag is still present in
 older versions.

https://github.com/lsegal/yard/commit/be17c0fec5022d20dce9f239b06d3055b588be0d
